### PR TITLE
View KRL functions and methods in Outline Window

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,4 +10,43 @@ export function activate(context: vscode.ExtensionContext) {
                 /^\s*(FOR.*|IF.*|ELSE|LOOP|REPEAT|WHILE.*|SWITCH.*|CASE.*|DEFAULT.*)\s*(;.*)?$/, "i"),
         },
     });
+
+    vscode.languages.registerDocumentSymbolProvider({ language: 'krl' }, new FunctionSymbolProvider());
 }
+
+class FunctionSymbolProvider implements vscode.DocumentSymbolProvider {
+  public provideDocumentSymbols(document: vscode.TextDocument): vscode.ProviderResult<vscode.SymbolInformation[]> {
+    const symbols: vscode.SymbolInformation[] = [];
+    
+    // Regular expressions for matching KRL functions and methods
+    const functionRegexes = [
+      { regex: /GLOBAL\s+DEF\s+\w+\s*\(.*\)/g, kind: vscode.SymbolKind.Function, isGlobal: true },   // Global method
+      { regex: /GLOBAL\s+DEFFCT\s+\w+\s+\w+\s*\(.*\)/g, kind: vscode.SymbolKind.Function, isGlobal: true }, // Global function
+      { regex: /DEF\s+\w+\s*\(.*\)/g, kind: vscode.SymbolKind.Method, isGlobal: false },             // Method
+      { regex: /DEFFCT\s+\w+\s+\w+\s*\(.*\)/g, kind: vscode.SymbolKind.Function, isGlobal: false }         // Function        
+    ];
+    
+    const text = document.getText();
+
+    for (const { regex, kind, isGlobal } of functionRegexes) {
+      let match;
+      while ((match = regex.exec(text))) {
+        const matchText = match[0];
+        const startPos = document.positionAt(match.index);
+        const endPos = document.positionAt(match.index + matchText.length);
+        const range = new vscode.Range(startPos, endPos);
+        const symbol = new vscode.SymbolInformation(
+          matchText,
+          isGlobal ? vscode.SymbolKind.Namespace : kind,  // Use Namespace kind for global functions and methods
+          isGlobal ? 'Global' : '',
+          new vscode.Location(document.uri, range)
+        );
+        symbols.push(symbol);
+      }
+    }
+
+    return symbols;
+  }
+}
+
+export function deactivate() {}


### PR DESCRIPTION
Maybe that would be a good addition. 
I have missed this function for a long time and now I've finally managed to implement it.

## Features
- Highlight KRL functions and methods in the outline view.
- Support for both local and global functions and methods.

![Outline](https://github.com/user-attachments/assets/530cc780-b418-4b79-8900-226470bc6205)
